### PR TITLE
Add support for loadbalancer interface

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -1,0 +1,64 @@
+- project:
+    templates:
+      - charm-unit-jobs
+    check:
+      jobs:
+      - xenial-ha-mysql
+      - xenial-postgres
+      - xenial-mysql
+      - bionic-postgres
+      - bionic-mysql
+      - focal-mysql8
+      - groovy-mysql8
+    vars:
+      needs_charm_build: true
+      charm_build_name: vault
+
+- job:
+    name: bionic-mysql
+    parent: func-target
+    dependencies:
+      - osci-lint
+      - tox-py35
+      - tox-py36
+      - tox-py37
+      - tox-py38
+    vars:
+      tox_extra_args: bionic-mysql
+- job:
+    name: xenial-ha-mysql
+    parent: func-target
+    dependencies: &smoke-jobs
+      - bionic-mysql
+    vars:
+      tox_extra_args: xenial-ha-mysql
+- job:
+    name: xenial-postgres
+    parent: func-target
+    dependencies: *smoke-jobs
+    vars:
+      tox_extra_args: xenial-postgres
+- job:
+    name: xenial-mysql
+    parent: func-target
+    dependencies: *smoke-jobs
+    vars:
+      tox_extra_args: xenial-mysql
+- job:
+    name: bionic-postgres
+    parent: func-target
+    dependencies: *smoke-jobs
+    vars:
+      tox_extra_args: bionic-postgres
+- job:
+    name: focal-mysql8
+    parent: func-target
+    dependencies: *smoke-jobs
+    vars:
+      tox_extra_args: focal-mysql8
+- job:
+    name: groovy-mysql8
+    parent: func-target
+    dependencies: *smoke-jobs
+    vars:
+      tox_extra_args: groovy-mysql8

--- a/rebuild
+++ b/rebuild
@@ -2,4 +2,4 @@
 # when dependencies of the charm change,
 # but nothing in the charm needs to.
 # simply change the uuid to something new
-83488fca-5745-11eb-9588-67771192e77f
+bee1368a-64d9-11eb-aa25-5f38d0366b65

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # Build requirements
-charm-tools>=2.4.4
+charm-tools>=2.4.4,<2.8
 
 # Workaround until https://github.com/juju/charm-tools/pull/589 gets
 # published

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # Build requirements
-charm-tools>=2.4.4,<2.8
+charm-tools==2.8.3
 
 # Workaround until https://github.com/juju/charm-tools/pull/589 gets
 # published

--- a/src/README.md
+++ b/src/README.md
@@ -219,6 +219,8 @@ Actions allow specific operations to be performed on a per-unit basis.
 * `reissue-certificates`
 * `resume`
 * `upload-signed-csr`
+* `reload`
+* `restart`
 
 To display action descriptions run `juju actions --schema vault`. If the charm
 is not deployed then see file `actions.yaml`.

--- a/src/README.md
+++ b/src/README.md
@@ -76,9 +76,9 @@ configured with the following charm configuration options:
 * `ssl-key`
 
 > **Note**: The process of encrypting the Vault API is separate from that of
-  using Vault to manage the encryption of OpenStack API services. See
-  [Managing TLS certificates with Vault][cdg-vault-certs] in the
-  [OpenStack Charms Deployment Guide][cdg] for details.
+ using Vault to manage the encryption of OpenStack API services. See [Managing
+ TLS certificates][cdg-vault-certs] in the [OpenStack Charms Deployment
+  Guide][cdg] for details.
 
 ## Post-deployment tasks
 
@@ -220,8 +220,8 @@ Actions allow specific operations to be performed on a per-unit basis.
 * `resume`
 * `upload-signed-csr`
 
-To display action descriptions run `juju actions vault`. If the charm is not
-deployed then see file `actions.yaml`.
+To display action descriptions run `juju actions --schema vault`. If the charm
+is not deployed then see file `actions.yaml`.
 
 ## High availability
 
@@ -234,14 +234,20 @@ Corosync and Pacemaker backend HA functionality.
 
 In addition, HA Vault will require the etcd and easyrsa applications.
 
-See [OpenStack high availability][cdg-ha-apps] in the [OpenStack Charms
+See [Infrastructure high availability][cdg-ha-apps] in the [OpenStack Charms
 Deployment Guide][cdg] for details.
+
+# Documentation
+
+The OpenStack Charms project maintains two documentation guides:
+
+* [OpenStack Charm Guide][cg]: for project information, including development
+  and support notes
+* [OpenStack Charms Deployment Guide][cdg]: for charm usage information
 
 # Bugs
 
 Please report bugs on [Launchpad][lp-bugs-charm-vault].
-
-For general charm questions refer to the [OpenStack Charm Guide][cg].
 
 <!-- LINKS -->
 

--- a/src/actions.yaml
+++ b/src/actions.yaml
@@ -134,3 +134,7 @@ pause:
   description: Pause the vault unit.
 resume:
   description: Resume the vault unit.
+restart:
+  description: Restarts the vault unit.
+reload:
+  description: Reloads the vault unit.

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -27,6 +27,7 @@ basic.init_config_states()
 
 import charmhelpers.core.hookenv as hookenv
 import charmhelpers.core.unitdata as unitdata
+import charmhelpers.core.host as host
 
 import charm.vault as vault
 import charm.vault_pki as vault_pki
@@ -164,6 +165,31 @@ def resume(args):
     handlers.resume_vault_unit()
 
 
+def restart(args):
+    """Restart the Vault service.
+
+    The result of this action will be to have vault daemon
+    restarted.
+    Mind that this action will cause the Vault to be sealed.
+
+    """
+    host.service_restart(service_name='vault')
+
+
+def reload(args):
+    """Reload the Vault service.
+
+    The result of this action will be to have vault daemon
+    reloaded (preferably with HUP signal in systemd).
+    That allows for live changes in listener (only certs)
+    without need of User intervention to unseal the vault.
+    Unfortunately other options like disable_mlock, ui
+    are not supported.
+
+    """
+    host.service_reload(service_name='vault')
+
+
 # Actions to function mapping, to allow for illegal python action names that
 # can map to a python function.
 ACTIONS = {
@@ -177,6 +203,8 @@ ACTIONS = {
     "disable-pki": disable_pki,
     "pause": pause,
     "resume": resume,
+    "restart": restart,
+    "reload": reload
 }
 
 

--- a/src/actions/reload
+++ b/src/actions/reload
@@ -1,0 +1,1 @@
+actions.py

--- a/src/actions/restart
+++ b/src/actions/restart
@@ -1,0 +1,1 @@
+actions.py

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -49,7 +49,8 @@ options:
       Virtual IP to use api traffic. You can provide up to two addresses
       configured on the access or external bindings. If neither binding
       is used then you can only provide one address that must be configured
-      on the default space.
+      on the default space. Mutually exclusive with the dns-ha-access-record
+      config option or lb-provider relation.
   channel:
     type: string
     default: stable
@@ -59,8 +60,8 @@ options:
     type: string
     default:
     description: |
-      DNS record to use for DNS HA with MAAS. Do not use vip setting
-      if this is set.
+      DNS record to use for DNS HA with MAAS. Mutually exclusive with the
+      vip config option or lb-provider relation.
   totally-unsecure-auto-unlock:
     type: boolean
     default: false

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -16,6 +16,7 @@ series:
 - bionic
 - focal
 - groovy
+- hirsute
 tags:
 - security
 extra-bindings:

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -32,6 +32,11 @@ requires:
   ha:
     interface: hacluster
     scope: container
+  lb-provider:
+    # Optional relation to a load balancer provider. Mutually exclusive
+    # with the vip or dns-ha-access-record config options.
+    interface: loadbalancer
+    limit: 1
 provides:
   nrpe-external-master:
     interface: nrpe-external-master

--- a/src/reactive/vault_handlers.py
+++ b/src/reactive/vault_handlers.py
@@ -790,7 +790,8 @@ def client_approle_authorized():
         return True
     except (vault.hvac.exceptions.InternalServerError,
             vault.VaultNotReady,
-            vault.hvac.exceptions.VaultDown):
+            vault.hvac.exceptions.VaultDown,
+            vault.requests.exceptions.ReadTimeout):
         log("InternalServerError: Unable to athorize approle. "
             "This may indicate failure to communicate with the database ",
             "WARNING")

--- a/src/templates/vault.service.j2
+++ b/src/templates/vault.service.j2
@@ -5,6 +5,7 @@ After=syslog.target
 [Service]
 Type=simple
 ExecStart=/snap/bin/vault server -config /var/snap/vault/common/vault.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=always
 User=root
 

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -10,3 +10,5 @@ psutil
 git+https://opendev.org/openstack/charms.openstack.git#egg=charms.openstack
 
 git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
+
+loadbalancer-interface

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 [testenv:build]
 basepython = python3
 commands =
-    charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
+    charm-build --log-level DEBUG -o {toxinidir}/build/builds src {posargs}
 
 [testenv:py3]
 basepython = python3

--- a/unit_tests/test_reactive_vault_handlers.py
+++ b/unit_tests/test_reactive_vault_handlers.py
@@ -462,6 +462,21 @@ class TestHandlers(unit_tests.test_utils.CharmTestCase):
             'New version of vault installed, manual intervention '
             'required to restart the service.')
 
+    @patch.object(handlers, 'leader_get')
+    @patch.object(handlers, 'client_approle_authorized')
+    @patch.object(handlers, '_assess_interface_groups')
+    @patch.object(handlers.vault, 'get_vault_health')
+    def test_assess_status_vault_missing_ca(self, get_vault_health,
+                                            _assess_interface_groups,
+                                            _client_approle_authorized,
+                                            _leader_get):
+        self.is_flag_set.side_effect = lambda f: (
+            True if f == 'certificates.certs.requested' else False
+        )
+        get_vault_health.return_value = self._health_response
+        handlers._assess_status()
+        self.status_set.assert_called_with('blocked', 'Missing CA cert')
+
     def test_assess_interface_groups(self):
         flags = {
             'db.master.available': True,


### PR DESCRIPTION
This adds support for the new loadbalancer interface which is intended to allow for load balancer / ingress endpoint providers, such as the cloud integrator charms, to provide a load balancer address upon request. The initial use-case for this is using Vault in Azure, where it is difficult or impossible to use a VIP or floating IP type approach for HA Vault; instead, this will allow a relation to the azure-integrator charm which will provide a native Azure LB which Vault can then advertise.

Change-Id: I5e0738429d47625c23bfe71c86df6266a3ea364b

**Note:** This is a draft PR for pre-review and testing. The official review will be submitted to OpenDev according to the OpenStack contributing guidelines.